### PR TITLE
Make Blizzard Pass completable

### DIFF
--- a/player.c
+++ b/player.c
@@ -1369,6 +1369,19 @@ static void  SimpleParser(void)
 	for(i = 0; i < nw ; i++)
 	{
 		Word[wn] = ParseWord(wb[i]);
+		/* Hack for Blizzard Pass verbs */
+		if (Blizzard && wn == 0)
+		{
+			/* Change SKIN to VSKI */
+			if (Word[wn] == 249)
+				Word[wn] = 43;
+			/* Change POLI to VPOL */
+			else if (Word[wn] == 175)
+				Word[wn] = 44;
+			/* Change noun DRAW(bridge) to verb DRAW */
+			else if (Word[wn] == 134)
+				Word[wn] = 49;
+		}
 		if(Word[wn])
 			wn++;
 	}

--- a/player.c
+++ b/player.c
@@ -550,6 +550,9 @@ static unsigned char NumObjects()
 
 static int CarryItem(void)
 {
+    /* Blizzard Pass has no inventory limit */
+    if (Blizzard)
+        return 1;
 	if(Flag[5] == Flag[4])
 		return 0;
 	if(Flag[5] < 255)


### PR DESCRIPTION
To make *Blizzard Pass* completable, we remove the inventory limit and correct some verbs that are misdetected as nouns.

The original sets flag 4 (inventory limit) to 4, but never seems to check it when taking. An inventory limit of 4 is not a lot, and to make matters worse, there are several places where an object is removed from the player's inventory without changing the carried count (flag 5), so the player may well end up unable to pick up anything at all. We fix this by simply ignoring the inventory limit and always returning true from `CarryItem()` if the game is *Blizzard Pass*.

I'm not sure how the original does this, but there are three crucial verbs, SKIN, POLISH and DRAW, which are always understood as their noun counterparts by the TaylorMade parser. We fix this by simply looking for them in the verb position if the game is Blizzard Pass and switching them to the correct verb.